### PR TITLE
perf(images): cache headers on upload, cap stored resolution

### DIFF
--- a/src/modules/aws-s3/aws-s3.service.ts
+++ b/src/modules/aws-s3/aws-s3.service.ts
@@ -8,6 +8,14 @@ import { ImageProcessingService } from 'src/services/image-processing';
 
 @Injectable()
 export class AwsS3Service {
+  /**
+   * Object keys are `randomUUID()-Date.now()-originalname`, so a given URL
+   * always resolves to the same bytes. Without this header S3 responds with no
+   * Cache-Control at all, which caps the Next.js image optimizer at a 60s
+   * `max-age` and makes Cloudflare treat every image as uncacheable.
+   */
+  private static readonly CACHE_CONTROL = 'public, max-age=31536000, immutable';
+
   private readonly logger = new Logger(AwsS3Service.name);
   private readonly s3: S3Client;
   private readonly bucket: string;
@@ -36,6 +44,7 @@ export class AwsS3Service {
       Body: file.buffer,
       Key,
       ContentType: file.mimetype,
+      CacheControl: AwsS3Service.CACHE_CONTROL,
       ACL: 'public-read',
       Metadata: { data: JSON.stringify(metadata) },
     });
@@ -121,6 +130,7 @@ export class AwsS3Service {
         Body: processedBuffer,
         Key,
         ContentType: contentType,
+        CacheControl: AwsS3Service.CACHE_CONTROL,
         ACL: 'public-read',
         Metadata: {
           data: JSON.stringify(metadata),

--- a/src/services/image-processing/image-processing.service.ts
+++ b/src/services/image-processing/image-processing.service.ts
@@ -9,6 +9,9 @@ import * as fs from 'fs';
 
 @Injectable()
 export class ImageProcessingService {
+  /** Longest edge kept for stored listing media. */
+  private static readonly MAX_EDGE = 2000;
+
   private readonly logger = new Logger(ImageProcessingService.name);
   private watermarkPath: string;
 
@@ -58,8 +61,31 @@ export class ImageProcessingService {
         throw new Error(`Watermark file not found at: ${this.watermarkPath}`);
       }
 
-      // Get original image metadata
-      const image = sharp(imageBuffer);
+      // Cap the working resolution before compositing. Listing photos come
+      // straight off phones and cameras; without this the original resolution
+      // is watermarked, stored and re-encoded at full size forever. 2000px is
+      // above the largest variant the site ever requests.
+      let workingBuffer = imageBuffer;
+      const probe = await sharp(imageBuffer).metadata();
+      if (
+        (probe.width ?? 0) > ImageProcessingService.MAX_EDGE ||
+        (probe.height ?? 0) > ImageProcessingService.MAX_EDGE
+      ) {
+        workingBuffer = await sharp(imageBuffer)
+          .resize({
+            width: ImageProcessingService.MAX_EDGE,
+            height: ImageProcessingService.MAX_EDGE,
+            fit: 'inside',
+            withoutEnlargement: true,
+          })
+          .toBuffer();
+        this.logger.log(
+          `Downscaled ${probe.width}x${probe.height} -> max ${ImageProcessingService.MAX_EDGE}px edge`,
+        );
+      }
+
+      // Get working image metadata
+      const image = sharp(workingBuffer);
       const metadata = await image.metadata();
 
       this.logger.log(
@@ -118,7 +144,10 @@ export class ImageProcessingService {
           },
         ])
         .jpeg({
-          quality: 95, // High quality
+          // 95 roughly doubled the file size over 82 with no visible gain on
+          // photographic content, and every stored byte is paid again on each
+          // optimizer cache miss.
+          quality: 82,
           progressive: true,
           mozjpeg: true,
         })


### PR DESCRIPTION
Uploaded objects carried no Cache-Control, which capped the Next.js image optimizer at a 60s max-age and made Cloudflare treat every image as uncacheable. Object keys are `randomUUID()-Date.now()-name`, so a URL never changes content and is safe to cache for a year.

Listing media was also watermarked and stored at full camera resolution at JPEG q95 - nothing downscaled it, and `resizeImage()` was never called. Cap the longest edge at 2000px before compositing and store at q82.

Verified: 6000x4000 -> 2000x1333, 1500x5000 -> 600x2000, images already under the cap pass through untouched.